### PR TITLE
update to use Filter from html5lib

### DIFF
--- a/bleach_extras/tag_tree_filter.py
+++ b/bleach_extras/tag_tree_filter.py
@@ -1,4 +1,5 @@
-from bleach.html5lib_shim import Filter
+import html5lib
+from html5lib.filters.base import Filter
 from bleach.sanitizer import (
     ALLOWED_ATTRIBUTES,
     ALLOWED_PROTOCOLS,
@@ -118,7 +119,7 @@ def clean_strip_content(
 
            Using filters changes the output of ``bleach.Cleaner.clean``.
            Make sure the way the filters change the output are secure.
-    
+
     To adjust the tags to strip, submit subclasses of ``TagTreeFilter`` to ``filters``.
 
     :returns: cleaned text as unicode


### PR DESCRIPTION
#### Before
While trying to `import bleach_extras` the following error occurs: 
```
In [5]: import bleach_extras
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
/Users/prateekshasingh/Documents/Frappe/frappe-bench/apps/frappe/frappe/commands/utils.pyc in <module>()
----> 1 import bleach_extras

/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/bleach_extras/__init__.py in <module>()
     14
     15
---> 16 from .tag_tree_filter import *

/Users/prateekshasingh/Documents/Frappe/frappe-bench/env/lib/python2.7/site-packages/bleach_extras/tag_tree_filter.py in <module>()
----> 1 from bleach.html5lib_shim import Filter
      2 from bleach.sanitizer import (
      3     ALLOWED_ATTRIBUTES,
      4     ALLOWED_PROTOCOLS,
      5     ALLOWED_STYLES,

ImportError: No module named html5lib_shim
```

#### After
I refered to https://github.com/mozilla/bleach/issues/234#issuecomment-285222639 for the fix, after which it works as expected:

```
In [11]: print(bleach_extras.clean_strip_content(dangerous, tags=['div'], ))
foo.<div>12</div>.bar
```

Do let me know your feedback and if there are any issues.